### PR TITLE
Unique the list of handlers for help to display

### DIFF
--- a/lib/lita/handlers/help.rb
+++ b/lib/lita/handlers/help.rb
@@ -42,7 +42,7 @@ module Lita
       def list_handlers
         robot.handlers.flat_map do |handler|
           handler.namespace if handler.respond_to?(:routes)
-        end.compact.sort
+        end.compact.uniq.sort
       end
 
       # Creates an array of help info for a specified handler. Optionally
@@ -65,7 +65,9 @@ module Lita
       # Filters the help output by an optional command.
       def filter_help(output, substring)
         return output if substring.nil?
-        output.select { |line| /(?:@?#{address})?#{substring}/i === line }
+        output.select do |line|
+          /(?:@?#{Regexp.escape(address)})?#{Regexp.escape(substring)}/i === line
+        end
       end
 
       # Formats an individual command's help message.

--- a/spec/lita/handlers/help_spec.rb
+++ b/spec/lita/handlers/help_spec.rb
@@ -17,15 +17,23 @@ describe Lita::Handlers::Help, lita_handler: true do
       end
     end
 
+    let(:dummy_handler_class2) do
+      Class.new(Lita::Handler) do
+        def self.name
+          "Dummy2"
+        end
+
+        namespace 'Dummy'
+      end
+    end
+
     before do
       registry.register_handler(dummy_handler_class)
-      allow(Gem).to receive(:loaded_specs).and_return(
-        { 'lita-dummy' => double('Gem', description: 'A dummy handler.') }
-      )
+      registry.register_handler(dummy_handler_class2)
       allow(robot.config.robot).to receive(:alias).and_return("!")
     end
 
-    it "lists all installed handlers in alphabetical order" do
+    it "lists all installed handlers in alphabetical order with duplicates removed" do
       send_command("help")
       expect(replies.last).to match(/^Type '!help HANDLER'.+installed:\ndummy\nhelp$/)
     end


### PR DESCRIPTION
Certain handlers (e.g. lita-locker) define routes in separate classes
under the same namespace, which caused them to be repeated in response
to the `help` command. This pull request solves the issue by uniquing
the list of handlers first.

I also discovered an issue where setting the bot's alias to '?' messed
with the regex in `filter_help`; I dealt with this by escaping the text
interpolated into the regex.
