### PR TITLE
Improve help handler usability

### DIFF
--- a/lib/lita/handlers/help.rb
+++ b/lib/lita/handlers/help.rb
@@ -7,27 +7,24 @@ module Lita
 
       feature :async_dispatch
 
-      route(
-        /^help\s*((?<handler>\S+)\s*(?<substring>.+)?)?/i,
-        :help, command: true, help: {
-          "help" => t("help.help_value"),
-          t("help.help_handler_key") => t("help.help_handler_value"),
-          t("help.help_command_key") => t("help.help_command_value")
-        }
-      )
+      route(/^help\s*(?<substring>.+)?/i, :help, command: true, help: {
+        "help" => t("help.help_value"),
+        t("help.help_string_key") => t("help.help_string_value")
+      })
 
       # Outputs help information about Lita commands.
       # @param response [Response] The response object.
       # @return [void]
       def help(response)
-        handler = response.match_data["handler"]
+        substring = response.match_data["substring"]
         return response.reply_privately(
           t("help.info", address: address) + "\n" + list_handlers.join("\n")
-        ) if handler.nil?
+        ) if substring.nil?
 
-        substring = response.match_data["substring"]
-        output = list_commands(handler, substring, response.user)
-        response.reply_privately(output.join("\n"))
+        handlers = matching_handlers(substring)
+        handlers_to_messages = map_handlers_to_messages(response, handlers)
+        messages = matching_messages(response, substring, handlers_to_messages)
+        response.reply_privately(format_reply(handlers_to_messages, messages))
       end
 
       private
@@ -47,35 +44,93 @@ module Lita
         end.compact.uniq.sort
       end
 
-      # Creates an array of help info for a specified handler. Optionally
-      # filters commands matching a given substring.
-      def list_commands(handler_name, substring, user)
-        handlers = robot.handlers.select { |handler| handler.namespace == handler_name.strip.downcase }
-        return [t('help.no_handler_found', handler: handler_name)] if handlers.empty?
-        output = handlers.map do |handler|
-          handler.routes.map do |route|
-            route.help.map do |command, description|
-              string = help_command(route, command, description)
-              string << t("help.unauthorized") unless authorized?(user, route.required_groups)
-              string
-            end
-          end
-        end.flatten
-        filter_help(output, substring)
+      # Creates an array of handlers matching the given substring.
+      def matching_handlers(substring)
+        name = substring.downcase.strip
+        return [] unless list_handlers.include?(name)
+        robot.handlers.select { |handler| handler.namespace == name }
       end
 
-      # Filters the help output by an optional command.
-      def filter_help(output, substring)
-        return output if substring.nil?
-        output.select do |line|
+      # Creates a hash of handler namespaces and their associated help messages.
+      def map_handlers_to_messages(response, handlers)
+        handlers_to_messages = {}
+        handlers.each do |handler|
+          messages = if handler.respond_to?(:routes)
+                       handler.routes.map do |route|
+                         route.help.map do |command, description|
+                           help_command(response, route, command, description)
+                         end
+                       end.flatten
+                     else
+                       []
+                     end
+          (handlers_to_messages[handler.namespace] ||= []).push(*messages)
+        end
+        handlers_to_messages
+      end
+
+      # Creates an array of help messages for all registered routes.
+      def all_help_messages(response)
+        robot.handlers.map do |handler|
+          next unless handler.respond_to?(:routes)
+
+          handler.routes.map do |route|
+            route.help.map do |command, description|
+              help_command(response, route, command, description)
+            end
+          end
+        end.flatten.compact
+      end
+
+      # Creates an array consisting of all help messages that match the given
+      # substring.
+      def all_matching_messages(response, substring)
+        filter_messages(all_help_messages(response), substring)
+      end
+
+      # Removes matching help messages that are already present in the
+      # comprehensive array of help messages defined by the requested
+      # handler(s).
+      def dedup_messages(handlers_to_messages, messages)
+        all_handler_messages = handlers_to_messages.values.flatten
+        messages.reject { |m| all_handler_messages.include?(m) }
+      end
+
+      # Creates an array of help messages matching the given substring, minus
+      # duplicates.
+      def matching_messages(response, substring, handlers_to_messages)
+        dedup_messages(handlers_to_messages, all_matching_messages(response, substring))
+      end
+
+      # Filters help messages matching a substring.
+      def filter_messages(messages, substring)
+        messages.select do |line|
           /(?:@?#{Regexp.escape(address)})?#{Regexp.escape(substring)}/i === line
         end
       end
 
+      # Formats a block of text associating a handler namespace with the help
+      # messages it defines.
+      def format_handler_messages(handler, messages)
+        "#{t('help.handler_contains', handler: handler)}:\n" + messages.join("\n") unless messages.empty?
+      end
+
+      # Formats the message to be sent in response to a help command.
+      def format_reply(handlers_to_messages, messages)
+        return t('help.no_help_found') if handlers_to_messages.empty? && messages.empty?
+        handler_messages = handlers_to_messages.keys.map do |handler|
+          format_handler_messages(handler, handlers_to_messages[handler]) 
+        end.compact
+        separator = handler_messages.empty? || messages.empty? ? "" : "\n\n"
+        [handler_messages, messages].map { |m| m.join("\n") }.join(separator)
+      end
+
       # Formats an individual command's help message.
-      def help_command(route, command, description)
+      def help_command(response, route, command, description)
         command = "#{address}#{command}" if route.command?
-        "#{command} - #{description}"
+        message = "#{command} - #{description}"
+        message << t("help.unauthorized") unless authorized?(response.user, route.required_groups)
+        message
       end
 
       # The way the bot should be addressed in order to trigger a command.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -23,12 +23,11 @@ en:
       help:
         help:
           help_value: Lists help information for terms and command the robot will respond to.
-          help_command_key: "help HANDLER [COMMAND]"
-          help_command_value: Lists help information for terms or commands in HANDLER that match COMMAND.
-          help_handler_key: help HANDLER
-          help_handler_value: Lists available commands for HANDLER.
-          info: "Type '%{address}help HANDLER' to list terms or commands for that handler. You may optionally specify a substring on which to filter after the handler name. The following handlers are installed:"
-          no_handler_found: "No matching handlers found for '%{handler}'"
+          help_string_key: "help STRING"
+          help_string_value: Lists help information for commands matching STRING.
+          handler_contains: "Handler '%{handler}' defines the following commands"
+          info: "Type '%{address}help STRING' to see matching help messages. STRING may either be the name of a handler or text matching a command/description. The following handlers are installed:"
+          no_help_found: "No matching handlers or commands found."
           unauthorized: " [Unauthorized]"
       info:
         help:


### PR DESCRIPTION
Changes to the help handler made in #1 required that the user be
familiar with the internals of the bot, e.g. knowing which handler
namespace a particular command is defined under in order to find it.
This PR removes the `help HANDLER STRING` syntax and simplifies it to
`help STRING`, where the argument can represent either the name of a
handler or a substring on which to filter all commands.

Example of usage and output:

> !help log
> Handler 'log' defines the following commands:
> !log LEVEL MESSAGE - Log a message to Lita's Logger object. Valid levels: UNKNOWN, FATAL, ERROR, WARN, INFO, DEBUG

!locker log <label> - Show up to the last 10 activity log entries for <label>
